### PR TITLE
Offer a uiSchema option to hide labels

### DIFF
--- a/src/render/utils.js
+++ b/src/render/utils.js
@@ -47,7 +47,7 @@ export function Label({
 }) {
   const label = uiSchema["ui:title"] || title || name;
   let { ["ui:options"]: { label: displayLabel = true } = {} } = uiSchema;
-  if (type === "object") {
+  if (type === "object" || uiSchema["ui:displayLabel"] == false) {
     displayLabel = false;
   }
   if (type === "boolean" && !uiSchema["ui:widget"]) {


### PR DESCRIPTION
This mostly is for array items, which do not get the label hide objects do.

When this isn't available, a nav tab containing array items will display the default uiSchema title as determined by react-jsonschema-form, which is sometimes undesirable based on how one customises the array field UI.

This option removes some unnecessary repetition in labels, because the nav title already serves as one.