### PR TITLE
Fix tabs render order in nested schema with ui-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "react-jsonschema-form-pagination",
   "description": "Extension of react-jsonschema-form with support for multi-nav forms",
   "private": false,
-  "author": "mavarazy@gmail.com",
+  "authors": [
+    "mavarazy@gmail.com"
+  ],
+  "contributors": [
+    {
+      "name": "Ayush",
+      "url": "https://github.com/Ayush1959"
+    }
+  ],
   "version": "0.4.1",
   "scripts": {
     "build:lib": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist": "npm run build:lib && npm run build:dist",
     "lint": "eslint src test playground --fix",
     "precommit": "lint-staged",
-    "prepare": "npm run dist",
+    "prepare": "npm run build:lib",
     "publish-to-gh-pages": "npm run build:playground && gh-pages --dist build/",
     "publish-to-npm": "npm run dist &&  npm publish && npm version patch",
     "start": "webpack-dev-server",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist": "npm run build:lib && npm run build:dist",
     "lint": "eslint src test playground --fix",
     "precommit": "lint-staged",
+    "prepare": "npm run dist",
     "publish-to-gh-pages": "npm run build:playground && gh-pages --dist build/",
     "publish-to-npm": "npm run dist &&  npm publish && npm version patch",
     "start": "webpack-dev-server",

--- a/src/splitter/NavTree.js
+++ b/src/splitter/NavTree.js
@@ -41,8 +41,10 @@ export default class NavTree {
 
       extractSubUiSchema(fields, aliases, this.uiSchema, uiSchema, this.schema);
 
+      const firstInUi = this.uiSchema?.[activeNav[0]]?.['ui:order']?.[0];
+      const firstField = firstInUi && `${activeNav[0]}.${firstInUi}`;
       if (navConfs.length > 0) {
-        asNavField(fields[0], navConfs, uiSchema);
+        asNavField(firstField || fields[0], navConfs, uiSchema);
       }
       navConfs = [];
     }

--- a/src/splitter/NavTree.js
+++ b/src/splitter/NavTree.js
@@ -41,8 +41,8 @@ export default class NavTree {
 
       extractSubUiSchema(fields, aliases, this.uiSchema, uiSchema, this.schema);
 
-      const firstInUi = this.uiSchema?.[activeNav[0]]?.['ui:order']?.[0];
-      const firstField = firstInUi && `${activeNav[0]}.${firstInUi}`;
+      const firstInUi = activeNav[0] && uiSchema && uiSchema[activeNav[0]] && uiSchema[activeNav[0]]['ui:order'] && uiSchema[activeNav[0]]['ui:order'][0];
+      const firstField = firstInUi ? activeNav[0] + '.' + firstInUi : null;
       if (navConfs.length > 0) {
         asNavField(firstField || fields[0], navConfs, uiSchema);
       }

--- a/src/splitter/extractTree.js
+++ b/src/splitter/extractTree.js
@@ -3,7 +3,7 @@ import {
   toArray,
   getNavAliases,
   findFieldNavs,
-  UI_ORDER,
+  UI_ORDER
 } from "../utils";
 
 export function findRelTree(tree, navs) {
@@ -19,7 +19,7 @@ function pushField(tree, field, uiAlias) {
   if (tree[GENERIC_NAV] === undefined) {
     tree[GENERIC_NAV] = {
       fields: [],
-      aliases: {},
+      aliases: {}
     };
   }
   tree[GENERIC_NAV].fields.push(field);
@@ -33,7 +33,12 @@ function fillSchemaConf(tree, schema, uiSchema, prefix = "") {
     const fieldSchema = schema.properties[field];
     const fieldUiSchema = uiSchema[field];
     if (fieldSchema.type === "object" && fieldUiSchema) {
-      fillSchemaConf(tree, fieldSchema, fieldUiSchema, field + ".");
+      fillSchemaConf(
+        tree,
+        fieldSchema,
+        fieldUiSchema,
+        prefix.length ? prefix + field + "." : field + "."
+      );
     } else {
       let navs = findFieldNavs(field, uiSchema);
       let subTree = findRelTree(tree, navs);

--- a/src/splitter/util.js
+++ b/src/splitter/util.js
@@ -4,7 +4,7 @@ export const asNavField = (field, navConfs, uiSchema) => {
     uiSchema[field] = {
       navConfs,
       "ui:field": "nav",
-      origUiSchema: uiSchema[field],
+      origUiSchema: uiSchema[field]
     };
   } else {
     const parentField = field.substr(0, separatorIndex);
@@ -17,13 +17,22 @@ export const asNavField = (field, navConfs, uiSchema) => {
 function asHiddenField(field, uiSchema) {
   uiSchema[field] = {
     "ui:widget": "hidden",
-    "ui:field": "hidden",
+    "ui:field": "hidden"
   };
 }
 
 export const toHiddenUiSchema = ({ properties }, uiSchema) => {
   let cleanUiSchema = Object.keys(properties).reduce((agg, field) => {
     asHiddenField(field, agg);
+    if (typeof properties[field] == "object") {
+      if ("properties" in properties[field]) {
+        Object.assign(
+          agg[field],
+          agg[field],
+          toHiddenUiSchema(properties[field], agg[field])
+        );
+      }
+    }
     return agg;
   }, Object.assign({}, uiSchema));
   return cleanUiSchema;


### PR DESCRIPTION
When we create a nested schema that employs a widget multiple times (not needed to give the same one multiple times) and provide a UI order for the inner schema, the tabs become disrupted. They revert to using the default JSON order, and during rendering, the tabs may be pushed down to the second or third row, depending on the first key. You can see a live preview of this issue in action by visiting this link: 
https://codesandbox.io/s/rsjf-widget-with-body-9gh2x6?file=/src/App.js